### PR TITLE
FEAT : Controller 테스트 케이스 + 커스텀 예외처리 member에 추가

### DIFF
--- a/MovMag/build.gradle
+++ b/MovMag/build.gradle
@@ -8,7 +8,7 @@ group = 'com.jejoonlee'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = "16"
+	sourceCompatibility = "1.8"
 }
 
 configurations {
@@ -32,10 +32,12 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'junit:junit:4.13.1'
+	testImplementation 'org.mockito:mockito-inline:2.13.0'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
 }
-targetCompatibility = JavaVersion.VERSION_16
+targetCompatibility = JavaVersion.VERSION_1_8

--- a/MovMag/src/main/java/com/jejoonlee/movmag/MovMagApplication.java
+++ b/MovMag/src/main/java/com/jejoonlee/movmag/MovMagApplication.java
@@ -2,9 +2,7 @@ package com.jejoonlee.movmag;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class MovMagApplication {
 

--- a/MovMag/src/main/java/com/jejoonlee/movmag/app/member/dto/MemberLogin.java
+++ b/MovMag/src/main/java/com/jejoonlee/movmag/app/member/dto/MemberLogin.java
@@ -10,6 +10,7 @@ public class MemberLogin {
     @Getter
     @Setter
     @AllArgsConstructor
+    @Builder
     public static class Request {
 
         @NotBlank(message="이메일을 입력해주세요")

--- a/MovMag/src/main/java/com/jejoonlee/movmag/app/member/security/SecurityConfig.java
+++ b/MovMag/src/main/java/com/jejoonlee/movmag/app/member/security/SecurityConfig.java
@@ -3,46 +3,42 @@ package com.jejoonlee.movmag.app.member.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true) // 어노테이션으로 권한 부여
 @RequiredArgsConstructor
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class SecurityConfig {
 
     private final JwtAuthenticationFilter authenticationFilter;
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http.httpBasic().disable()
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .httpBasic().disable()
                 .csrf().disable()
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and()
+                .cors().and()
+                .headers().frameOptions().disable().and()
                 .authorizeRequests()
-                .antMatchers("/**/register").permitAll() // 토큰 없이 접근 가능
-                .and()
-                .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
-
+                .antMatchers("/member/**").permitAll()
+                .and().addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
     }
 
-//    @Override
-//    public void configure(final WebSecurity web) throws Exception {
-//        // 주로 개발 관련
-//        web.ignoring()
-//                .antMatchers("");
+//    @Bean
+//    public WebSecurityCustomizer webSecurityCustomizer() {
+//        return (web) -> web.ignoring().antMatchers("/ignore1", "/ignore2");
 //    }
 
-    @Bean
-    @Override
-    public AuthenticationManager authenticationManagerBean() throws Exception {
-        return super.authenticationManagerBean();
-    }
+
+//    @Bean
+//    public AuthenticationManager authenticationManagerBean() throws Exception {
+//        return super.authenticationManagerBean();
+//    }
 
 }

--- a/MovMag/src/main/java/com/jejoonlee/movmag/app/member/security/TokenProvider.java
+++ b/MovMag/src/main/java/com/jejoonlee/movmag/app/member/security/TokenProvider.java
@@ -33,8 +33,8 @@ public class TokenProvider {
         claims.put(EMAIL, email);
         claims.put(KEY_ROLES, role); // key value로 저장
 
-        var now = new Date();
-        var expiredDate = new Date(now.getTime() + VALIDATE_TIME);
+        Date now = new Date();
+        Date expiredDate = new Date(now.getTime() + VALIDATE_TIME);
 
         return Jwts.builder()
                 .setClaims(claims)
@@ -57,7 +57,7 @@ public class TokenProvider {
         // 토큰이 빈 문자열이면 false
         if (!StringUtils.hasText(token)) return false;
 
-        var claims = parseClaims(token);
+        Claims claims = parseClaims(token);
         return !claims.getExpiration().before(new Date()); //토큰 만료 시간이 현재보다 이전인지 아닌지 만료 여부 확인
     }
 

--- a/MovMag/src/main/java/com/jejoonlee/movmag/app/member/service/impl/MemberServiceImpl.java
+++ b/MovMag/src/main/java/com/jejoonlee/movmag/app/member/service/impl/MemberServiceImpl.java
@@ -6,6 +6,8 @@ import com.jejoonlee.movmag.app.member.dto.MemberLogin;
 import com.jejoonlee.movmag.app.member.dto.MemberRegister;
 import com.jejoonlee.movmag.app.member.repository.MemberRepository;
 import com.jejoonlee.movmag.app.member.service.MemberService;
+import com.jejoonlee.movmag.exception.ErrorCode;
+import com.jejoonlee.movmag.exception.MemberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -24,7 +26,7 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
     public MemberRegister.Response register(MemberRegister.Request request) {
 
         if (memberRepository.existsByEmail(request.getEmail())) {
-            throw new RuntimeException("입력한 이메일이 이미 존재합니다");
+            throw new MemberException(ErrorCode.EMAIL_EXISTS);
         }
 
         // 비밀번호 encoding 하기
@@ -46,7 +48,7 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
         MemberDto user = (MemberDto) loadUserByUsername(request.getEmail());
 
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-            throw new RuntimeException("비밀번호가 일치하지 않습니다");
+            throw new MemberException(ErrorCode.PASSWORD_NOT_MATCH);
         }
 
         return MemberLogin.Response.fromDto(user);
@@ -56,7 +58,7 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
 
         MemberEntity member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("유저가 존재하지 않습니다"));
+                .orElseThrow(() -> new MemberException(ErrorCode.USER_NOT_FOUND));
 
         return MemberDto.fromEntity(member);
     }

--- a/MovMag/src/main/java/com/jejoonlee/movmag/config/JpaAuditingConfiguration.java
+++ b/MovMag/src/main/java/com/jejoonlee/movmag/config/JpaAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package com.jejoonlee.movmag.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+}

--- a/MovMag/src/main/java/com/jejoonlee/movmag/exception/ErrorCode.java
+++ b/MovMag/src/main/java/com/jejoonlee/movmag/exception/ErrorCode.java
@@ -12,9 +12,11 @@ public enum ErrorCode {
     NO_INPUT("빈칸 값이 있습니다"),
     JWT_SHOULD_NOT_BE_TRUSTED("JWT 토큰의 유효성이 확인이 안 됩니다. 다시 입력해주세요"),
     WRONG_INPUT_REQUEST("입력값을 제대로 입력하지 않았습니다. 다시 확인해주세요"),
+    HTTP_REQUEST_BODY_ERROR("HTTP body에 문제가 생겼습니다. 다시 확인해주세요"),
 
     // 유저 관련 에러 코드
     USER_NOT_FOUND("없는 유저입니다"),
+    EMAIL_EXISTS("이미 이메일이 존재합니다"),
     PASSWORD_NOT_MATCH("비밀번호가 일치하지 않습니다"),
     USER_PERMISSION_NOT_GRANTED("해당 요청에 대한 권한이 없습니다. JWT 토큰을 헤더에 추가하거나, 다른 로그인 정보로 로그인해주세요");
 

--- a/MovMag/src/main/java/com/jejoonlee/movmag/exception/ErrorResponse.java
+++ b/MovMag/src/main/java/com/jejoonlee/movmag/exception/ErrorResponse.java
@@ -10,4 +10,11 @@ import lombok.*;
 public class ErrorResponse {
     private ErrorCode errorCode;
     private String errorMessage;
+
+    public static ErrorResponse getErrorCode(ErrorCode code) {
+        return ErrorResponse.builder()
+                .errorCode(code)
+                .errorMessage(code.getDescription())
+                .build();
+    }
 }

--- a/MovMag/src/main/java/com/jejoonlee/movmag/exception/GlobalExceptionHandler.java
+++ b/MovMag/src/main/java/com/jejoonlee/movmag/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.jejoonlee.movmag.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -18,10 +19,11 @@ import java.util.Map;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(MemberException.class)
-    public ErrorResponse handleMemberException(MemberException e) {
+    public ResponseEntity<ErrorResponse> handleMemberException(MemberException e) {
         log.error("{} has occurred.", e.getErrorCode());
 
-        return new ErrorResponse(e.getErrorCode(), e.getErrorMessage());
+        return ResponseEntity.badRequest().body(
+                ErrorResponse.getErrorCode(e.getErrorCode()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -38,56 +40,50 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)
-    public ErrorResponse handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
         log.error("DataIntegrityViolationException has occurred : " + e.getMessage(), e);
 
-        return new ErrorResponse(
-                ErrorCode.INVALID_REQUEST,
-                ErrorCode.INVALID_REQUEST.getDescription()
-        );
+        return ResponseEntity.badRequest().body(
+                ErrorResponse.getErrorCode(ErrorCode.INVALID_REQUEST));
     }
 
     @ExceptionHandler(AccessDeniedException.class)
-    public ErrorResponse handleAccessDeniedException(AccessDeniedException e) {
+    public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
         log.error("AccessDeniedException has occurred: " + e.getMessage(), e);
 
-        return new ErrorResponse(
-                ErrorCode.USER_PERMISSION_NOT_GRANTED,
-                ErrorCode.USER_PERMISSION_NOT_GRANTED.getDescription());
+        return ResponseEntity.badRequest().body(
+                ErrorResponse.getErrorCode(ErrorCode.USER_PERMISSION_NOT_GRANTED));
     }
 
     @ExceptionHandler(NullPointerException.class)
-    public ErrorResponse handleNullPointerException(NullPointerException e) {
+    public ResponseEntity<ErrorResponse> handleNullPointerException(NullPointerException e) {
         log.error("NullPointerException has occurred : " + e.getMessage());
 
-        return new ErrorResponse(
-                ErrorCode.NO_INPUT,
-                ErrorCode.NO_INPUT.getDescription());
+        return ResponseEntity.badRequest().body(
+                ErrorResponse.getErrorCode(ErrorCode.NO_INPUT));
     }
 
     @ExceptionHandler(SignatureException.class)
-    public ErrorResponse handleSignatureException(SignatureException e) {
+    public ResponseEntity<ErrorResponse> handleSignatureException(SignatureException e) {
         log.error("SignatureException has occured : " + e.getMessage());
 
-        return new ErrorResponse(
-                ErrorCode.JWT_SHOULD_NOT_BE_TRUSTED,
-                ErrorCode.JWT_SHOULD_NOT_BE_TRUSTED.getDescription());
+        return ResponseEntity.badRequest().body(
+                ErrorResponse.getErrorCode(ErrorCode.JWT_SHOULD_NOT_BE_TRUSTED));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleJsonParseException(HttpMessageNotReadableException e) {
+        log.error("HttpMessageNotReadableException has occured : " + e.getMessage());
+
+        return ResponseEntity.badRequest().body(
+                ErrorResponse.getErrorCode(ErrorCode.HTTP_REQUEST_BODY_ERROR));
     }
 
     @ExceptionHandler(Exception.class)
-    public ErrorResponse handleException(Exception e) {
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
         log.error("Exception has occurred: " + e.getMessage(), e);
 
-        if (e.getMessage().split(":")[0].equals("JSON parse error")) {
-            log.error(e.getMessage());
-
-            return new ErrorResponse(
-                    ErrorCode.WRONG_INPUT_REQUEST,
-                    ErrorCode.WRONG_INPUT_REQUEST.getDescription());
-        }
-
-        return new ErrorResponse(
-                ErrorCode.INTERNAL_SERVER_ERROR,
-                ErrorCode.INTERNAL_SERVER_ERROR.getDescription());
+        return ResponseEntity.internalServerError().body(
+                ErrorResponse.getErrorCode(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 }

--- a/MovMag/src/test/java/com/jejoonlee/movmag/controller/MemberControllerTest.java
+++ b/MovMag/src/test/java/com/jejoonlee/movmag/controller/MemberControllerTest.java
@@ -1,0 +1,110 @@
+package com.jejoonlee.movmag.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jejoonlee.movmag.app.member.controller.MemberController;
+import com.jejoonlee.movmag.app.member.dto.MemberLogin;
+import com.jejoonlee.movmag.app.member.dto.MemberRegister;
+import com.jejoonlee.movmag.app.member.security.TokenProvider;
+import com.jejoonlee.movmag.app.member.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+public class MemberControllerTest {
+
+    @MockBean
+    private TokenProvider tokenProvider;
+
+    @MockBean
+    private MemberService memberService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private String EMAIL = "joons@naver.com";
+    private String USERNAME = "joons";
+    private String PASSWORD = "joons1234!";
+    private String PHONE_NUM = "010-1234-1234";
+    private String ROLE = "User";
+
+    @Test
+    @DisplayName("회원가입 성공 테스트")
+    @WithMockUser
+    void successRegisterMember() throws Exception {
+    //given
+
+        MemberRegister.Request request = MemberRegister.Request.builder()
+                .email(EMAIL)
+                .username(USERNAME)
+                .password(PASSWORD)
+                .phoneNum(PHONE_NUM)
+                .role(ROLE)
+                .build();
+
+        MemberRegister.Response response = MemberRegister.Response.builder()
+                .email(EMAIL)
+                .username(USERNAME)
+                .role(ROLE)
+                .build();
+
+        given(memberService.register(any()))
+                .willReturn(response);
+    //when
+    //then
+        mockMvc.perform(post("/member/register")
+                        .with(SecurityMockMvcRequestPostProcessors.csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").exists())
+                .andExpect(jsonPath("$.username").exists())
+                .andExpect(jsonPath("$.role").exists())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("로그인 성공 테스트")
+    @WithMockUser
+    void successLogin() throws Exception {
+        //given
+
+        MemberLogin.Request request = MemberLogin.Request.builder()
+                .email(EMAIL)
+                .password(PASSWORD)
+                .build();
+
+        MemberLogin.Response response = MemberLogin.Response.builder()
+                .email(EMAIL)
+                .memberId(1L)
+                .role(ROLE)
+                .build();
+
+        given(memberService.login(any()))
+                .willReturn(response);
+        //when
+        //then
+        mockMvc.perform(post("/member/login")
+                        .with(SecurityMockMvcRequestPostProcessors.csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(request)))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- var 타입 없애기 (TokenProvider.java에서)
- Java 16에서 1.8로 바꾸기 (원래 1.8을 계획했는데, 16으로 세팅이 되어 있었다)
- GlobalExceptionHandler 모든 리턴 값을 ResponseEntity로 설정
    - ResponseEntity로 리턴을 안 하다 보니, HTTP 200으로 나오고, 에러 내용이 나온다
- Json Parse Error 나오는 부분을, HttpMessageNotReadableException을 사용해서 커스텀 예외처리
- SecurityConfig에서 deprecated 된 ****WebSecurityConfigurerAdapter**** 미사용
- member 컨트롤러 테스트 케이스

**TO-BE**
- member service 테스트 케이스 작성

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 